### PR TITLE
Vector map default

### DIFF
--- a/cmake/rosparam_handler-macros.cmake
+++ b/cmake/rosparam_handler-macros.cmake
@@ -1,5 +1,19 @@
 
 macro(generate_ros_parameter_files)
+
+    set(CMAKE_CPP11_FLAG_ENABLED FALSE)
+
+    foreach (flag ${CMAKE_CXX_FLAGS})
+      message(WARNING "flag" "${flag}")
+      if (flag MATCHES "-std=c\\+\\+0x|-std=c\\+\\+11")
+        set (CMAKE_CPP11_FLAG_ENABLED TRUE)
+      endif ()
+    endforeach (flag)
+
+    if (NOT CMAKE_CPP11_FLAG_ENABLED)
+      message(FATAL_ERROR "cpp11 support is required and is not enabled! (e.g. -std=c++11)")
+    endif()
+
     set(CFG_FILES "${ARGN}")
     set(ROSPARAM_HANDLER_ROOT_DIR "${ROSPARAM_HANDLER_CMAKE_DIR}/..")
     if (${PROJECT_NAME}_CATKIN_PACKAGE)

--- a/cmake/rosparam_handler-macros.cmake
+++ b/cmake/rosparam_handler-macros.cmake
@@ -4,14 +4,13 @@ macro(generate_ros_parameter_files)
     set(CMAKE_CPP11_FLAG_ENABLED FALSE)
 
     foreach (flag ${CMAKE_CXX_FLAGS})
-      message(WARNING "flag" "${flag}")
       if (flag MATCHES "-std=c\\+\\+0x|-std=c\\+\\+11")
         set (CMAKE_CPP11_FLAG_ENABLED TRUE)
       endif ()
     endforeach (flag)
 
     if (NOT CMAKE_CPP11_FLAG_ENABLED)
-      message(FATAL_ERROR "cpp11 support is required and is not enabled! (e.g. -std=c++11)")
+      message(SEND_ERROR "cpp11 support is required and is not enabled! (e.g. -std=c++11)")
     endif()
 
     set(CFG_FILES "${ARGN}")

--- a/doc/HowToWriteYourFirstParamsFile.md
+++ b/doc/HowToWriteYourFirstParamsFile.md
@@ -36,6 +36,9 @@ gen.add("map_param", paramtype="std::map<std::string,std::string>", description=
 gen.add("weight", paramtype="double",description="Weight can not be negative", min=0.0)
 gen.add("age", paramtype="int",description="Normal age of a human is inbetween 0 and 100", min=0, max=100)
 gen.add("default_param", paramtype="std::string",description="Parameter with default value", default="Hello World")
+# Default vector/map
+gen.add("vector_bool", paramtype="std::vector<bool>", description="A vector of boolean with default value.", default=[False, True, True, False, True])
+gen.add("map_string_float", paramtype="std::map<std::string,float>", description="A map of <std::string,float> with default value.", default={"a":0.1, "b":1.2, "c":2.3, "d":3.4, "e":4.5})
 
 # Constant and configurable parameters
 gen.add("optimal_parameter", paramtype="double", description="Optimal parameter, can not be set via rosparam", default=10, constant=True)

--- a/src/rosparam_handler/parameter_generator_catkin.py
+++ b/src/rosparam_handler/parameter_generator_catkin.py
@@ -141,20 +141,29 @@ class ParameterGenerator(object):
         """
 
         if param['type'].strip() == "std::string" and (param['max'] is not None or param['min'] is not None):
-            eprint(param['name'],"Max or min specified for for variable of type string")
-        if (param['is_vector'] or param['is_map']) and (param['max'] or param['min'] or param['default']):
-            eprint(param['name'],"Max, min and default can not be specified for variable of type %s" % param['type'])
+            eprint(param['name'], "Max or min specified for for variable of type string")
+
+        in_type = param['type'].strip()
+        if in_type.startswith('std::vector'):
+            param['is_vector'] = True
+        if in_type.startswith('std::map'):
+            param['is_map'] = True
+
+        if (param['is_vector'] or param['is_map']):
+            if (param['max'] or param['min']):
+                eprint(param['name'], "Max and min can not be specified for variable of type %s" % param['type'])
+
         pattern = r'^[a-zA-Z][a-zA-Z0-9_]*$'
         if not re.match(pattern, param['name']):
-            eprint(param['name'],"The name of field does not follow the ROS naming conventions, "
-                                 "see http://wiki.ros.org/ROS/Patterns/Conventions")
+            eprint(param['name'], "The name of field does not follow the ROS naming conventions, "
+                   "see http://wiki.ros.org/ROS/Patterns/Conventions")
         if param['configurable'] and (
-                            param['global_scope'] or param['is_vector'] or param['is_map'] or param['constant']):
-            eprint(param['name'],"Global Parameters, vectors, maps and constant params can not be declared configurable! ")
+           param['global_scope'] or param['is_vector'] or param['is_map'] or param['constant']):
+            eprint(param['name'], "Global Parameters, vectors, maps and constant params can not be declared configurable! ")
         if param['global_scope'] and param['default'] is not None:
-            eprint(param['name'],"Default values for global parameters should not be specified in node! ")
+            eprint(param['name'], "Default values for global parameters should not be specified in node! ")
         if param['constant'] and param['default'] is None:
-            eprint(param['name'],"Constant parameters need a default value!")
+            eprint(param['name'], "Constant parameters need a default value!")
         if param['name'] in [p['name'] for p in self.parameters]:
             eprint(param['name'],"Parameter with the same name exists already")
         if param['edit_method'] == '':
@@ -163,23 +172,20 @@ class ParameterGenerator(object):
             param['configurable'] = True
 
         # Check type
-        in_type = param['type'].strip()
-        if in_type.startswith('std::vector'):
-            param['is_vector'] = True
+        if param['is_vector']:
             ptype = in_type[12:-1].strip()
             self._test_primitive_type(param['name'], ptype)
             param['type'] = 'std::vector<{}>'.format(ptype)
-        elif in_type.startswith('std::map'):
-            param['is_map'] = True
+        elif param['is_map']:
             ptype = in_type[9:-1].split(',')
             if len(ptype) != 2:
-                eprint(param['name'],"Wrong syntax used for setting up std::map<... , ...>: You provided '%s' with "
-                                "parameter %s" % in_type)
+                eprint(param['name'], "Wrong syntax used for setting up std::map<... , ...>: You provided '%s' with "
+                       "parameter %s" % in_type)
             ptype[0] = ptype[0].strip()
             ptype[1] = ptype[1].strip()
             if ptype[0] != "std::string":
-                eprint(param['name'],"Can not setup map with %s as key type. Only std::map<std::string, "
-                                     "...> are allowed" % ptype[0])
+                eprint(param['name'], "Can not setup map with %s as key type. Only std::map<std::string, "
+                       "...> are allowed" % ptype[0])
             self._test_primitive_type(param['name'], ptype[0])
             self._test_primitive_type(param['name'], ptype[1])
             param['type'] = 'std::map<{},{}>'.format(ptype[0], ptype[1])
@@ -232,6 +238,48 @@ class ParameterGenerator(object):
         elif param['type'] == 'bool':
             value = str(param[field]).capitalize()
         return str(value)
+
+    @staticmethod
+    def _get_cvaluelist(param, field):
+        """
+        Helper function to convert python list of strings and booleans to correct C++ syntax
+        :param param:
+        :return: C++ compatible representation
+        """
+        values = param[field]
+        assert(isinstance(values, list))
+        form = ""
+        for value in values:
+            if param['type'] == 'std::vector<std::string>':
+                value = '"{}"'.format(value)
+            elif param['type'] == 'std::vector<bool>':
+                value = str(value).lower()
+            else:
+                value = str(value)
+            form += value + ','
+        # remove last ','
+        return form[:-1]
+
+    @staticmethod
+    def _get_cvaluedict(param, field):
+        """
+        Helper function to convert python dict of strings and booleans to correct C++ syntax
+        :param param:
+        :return: C++ compatible representation
+        """
+        values = param[field]
+        assert(isinstance(values, dict))
+        form = ""
+        for key, value in values.items():
+            if param['type'] == 'std::map<std::string,std::string>':
+                pair = '{{"{}","{}"}}'.format(key, value)
+            elif param['type'] == 'std::map<std::string,bool>':
+                pair = '{{"{}",{}}}'.format(key, str(value).lower())
+            else:
+                pair = '{{"{}",{}}}'.format(key, str(value))
+            form += pair + ','
+        # remove last ','
+        return form[:-1]
 
     def generate(self, pkgname, nodename, classname):
         """
@@ -343,7 +391,12 @@ class ParameterGenerator(object):
                                                    '\\n"\n').substitute(
                     namespace=namespace, name=name, type=param["type"]))
             else:
-                default = ', {}'.format(str(param['type']) + "{" + self._get_cvalue(param, "default") + "}")
+                if param['is_vector']:
+                    default = ', {}'.format(str(param['type']) + "{" + self._get_cvaluelist(param, "default") + "}")
+                elif param['is_map']:
+                    default = ', {}'.format(str(param['type']) + "{" + self._get_cvaluedict(param, "default") + "}")
+                else:
+                    default = ', {}'.format(str(param['type']) + "{" + self._get_cvalue(param, "default") + "}")
 
             # Test for constant value
             if param['constant']:


### PR DESCRIPTION
On master the function 

``` python
def _perform_checks(self, param):
```

actually set the `is_vector/is_map` param after checking for the `min/max/default` value so that none of them are actually properly handled.

This PR fix this issue and  enable vector/map default value but warn the user that this feature requires cpp11.

The following works fine : 

``` python
gen.add("vector_bool", paramtype="std::vector<bool>", description="A vector of bool.", default='0, 1, 1, 0, 1')
gen.add("vector_int", paramtype="std::vector<int>", description="A vector of int.", default='0, 1, 2, 3, 4')
gen.add("vector_float", paramtype="std::vector<float>", description="A vector of float.", default='0.1, 1.2, 2.3, 3.4, 4.5')
gen.add("vector_double", paramtype="std::vector<double>", description="A vector of double.", default='0.01, 1.02, 2.03, 3.04, 4.05')
gen.add("vector_string", paramtype="std::vector<std::string>", description="A vector of std::string.", default='"a", "b", "c", "D"')

gen.add("map_string_bool", paramtype="std::map<std::string,bool>", description="A map of <std::string,bool>.", default='{"a",0}, {"b",1}, {"c",1}, {"d",0}, {"e",1}')
gen.add("map_string_int", paramtype="std::map<std::string,int>", description="A map of <std::string,integer>.", default='{"a",0}, {"b",1}, {"c",2}, {"d",3}, {"e",4}')
gen.add("map_string_float", paramtype="std::map<std::string,float>", description="A map of <std::string,float>.", default='{"a",0.1}, {"b",1.2}, {"c",2.3}, {"d",3.4}, {"e",4.5}')
gen.add("map_string_double", paramtype="std::map<std::string,double>", description="A map of <std::string,double>.", default='{"a",0.01}, {"b",1.02}, {"c",2.03}, {"d",3.04}, {"e",4.05}')
gen.add("map_string_string", paramtype="std::map<std::string,std::string>", description="A map of <std::string,std::string>.", default='{"a","aa"}, {"b","bb"}, {"c","cc"}, {"d","dd"}, {"e","ee"}')
```

Printing warning such as :

``` python
************************************************
Warning when setting up parameter 'vector_bool':
Default value for std::vector<bool> can only be specified if cpp11 flag is enabled ! (e.g. -std=c++11)
************************************************
```

The following doesn't work, as expected : 

``` python
gen.add("vector_int_min", paramtype="std::vector<int>", description="A vector of int.", default='0, 1', min='0, 0')
gen.add("vector_int_max", paramtype="std::vector<int>", description="A vector of int.", default='0, 1', max='10, 10')

gen.add("map_string_int_min", paramtype="std::map<std::string,int>", description="A map of <std::string,int>.", default='{"a",0}, {"b",1}, {"c",1}, {"d",0}, {"e",1}', min='{"a",0}, {"b",0}')
gen.add("map_string_int_max", paramtype="std::map<std::string,int>", description="A map of <std::string,int>.", default='{"a",0}, {"b",1}, {"c",1}, {"d",0}, {"e",1}', max='{"a",10}, {"b",10}')
```
