### PR TITLE
add missing include

### DIFF
--- a/templates/Parameters.h.template
+++ b/templates/Parameters.h.template
@@ -12,6 +12,7 @@
 #include <string>
 #include <limits>
 #include <ros/param.h>
+#include <ros/node_handle.h>
 #ifdef DYNAMIC_RECONFIGURE_FOUND
 #include <${pkgname}/${ClassName}Config.h>
 #else


### PR DESCRIPTION
  NodeHandle is forward declared in ros header forward.h
  but used in 'DummyParameters.h' before being defined.

If the auto generated `DummyParameters.h` config file is included before the `ros/node_handle.h` header the following error pops : 

`error: invalid use of incomplete type const class ros::NodeHandle`

This is due to the fact that `DummyParameters.h` includes `ros/params.h` which itself includes the ros header `forwards.h` which only forward declare NodeHandle class (nh).
The function 

``` cpp
std::string getNodeName(const ros::NodeHandle& privateNodeHandle)
```

uses nh before it is actually defined.
