### PR TITLE
Allow multiple configuration files per package

### DIFF
--- a/templates/Parameters.h.template
+++ b/templates/Parameters.h.template
@@ -22,6 +22,8 @@ struct ${ClassName}Config{};
 
 namespace ${pkgname} {
 
+#ifndef UTIL_FUNCTIONS_${pkgname}
+#define UTIL_FUNCTIONS_${pkgname}
 inline std::string getNodeName(const ros::NodeHandle& privateNodeHandle){
     std::string name_space = privateNodeHandle.getNamespace();
     std::stringstream tempString(name_space);
@@ -53,6 +55,8 @@ std::ostream &operator<<(std::ostream &stream, const std::map<T1, T2>& map)
   stream << '}';
   return stream;
 }
+
+#endif /* UTIL_FUNCTIONS_${pkgname} */
 
 struct ${ClassName}Parameters {
 


### PR DESCRIPTION
When using multiple configuration files in one package, you will get a "redefinition" error during the compilation, e.g:
`... <myConfig>Parameters.h:27:20: error: redefinition of 'std::__cxx11::string <myPackageName>:getNodeName(const ros::NodeHandle&)'`

The attached preprocessor statements avoid the redefinition.