### PR TITLE
[enhancement] add support for parameter groups (as in dynamic_reconfigure)

### DIFF
--- a/doc/HowToWriteYourFirstParamsFile.md
+++ b/doc/HowToWriteYourFirstParamsFile.md
@@ -56,6 +56,10 @@ global_scope=False, constant=False)
 gen.add_enum("my_enum", description="My first self written enum",
 entry_strings=["Small", "Medium", "Large", "ExtraLarge"], default="Medium"))
 
+# Add a subgroup
+my_group = gen.add_group("my_group")
+my_group.add("subparam", paramtype="std::string", description="This parameter is part of a group", configurable=True)
+
 #Syntax : Package, Node, Config Name(The final name will be MyDummyConfig)
 exit(gen.generate("rosparam_tutorials", "example_node", "Tutorial"))
 ```
@@ -126,7 +130,15 @@ gen.add_enum("my_enum", description="My first self written enum",
 entry_strings=["Small", "Medium", "Large", "ExtraLarge"], default="Medium"))
 ```
 
-Finally, by using the add_enum function, an enum for the dynamic_reconfigure window can be easily defined. The entry_strings will also be static parameters of the resulting parameter struct.
+By using the add_enum function, an enum for the dynamic_reconfigure window can be easily defined. The entry_strings will also be static parameters of the resulting parameter struct.
+
+```python
+# Add a subgroup
+my_group = gen.add_group("my_group")
+my_group.add("subparam", paramtype="std::string", description="This parameter is part of a group", configurable=True)
+```
+
+Finally, by using the add_group function, you can sort parameters into groups in the dynamic_reconfigure window. This obviously only makes sense for configurable parameters.
 
 ```python
 exit(gen.generate("rosparam_tutorials", "example_node", "Tutorial"))

--- a/src/rosparam_handler/parameter_generator_catkin.py
+++ b/src/rosparam_handler/parameter_generator_catkin.py
@@ -46,10 +46,17 @@ def eprint(*args, **kwargs):
 class ParameterGenerator(object):
     """Automatic config file and header generator"""
 
-    def __init__(self):
+    def __init__(self, parent=None, group=""):
         """Constructor for ParamGenerator"""
         self.enums = []
         self.parameters = []
+        self.childs = []
+        self.parent = parent
+        if group:
+            self.group = group
+        else:
+            self.group = "gen"
+        self.group_variable = filter(str.isalnum, self.group)
 
         if len(sys.argv) != 4:
             eprint("ParameterGenerator: Unexpected amount of args, did you try to call this directly? You shouldn't do this!")
@@ -61,6 +68,18 @@ class ParameterGenerator(object):
         self.pkgname = None
         self.nodename = None
         self.classname = None
+
+    def add_group(self, name):
+        """
+        Add a new group in the dynamic reconfigure selection
+        :param name: name of the new group
+        :return: a new group object that you can add parameters to
+        """
+        if not name:
+            eprint("You have added a group with an empty group name. This is not supported!")
+        child = ParameterGenerator(self, name)
+        self.childs.append(child)
+        return child
 
     def add_enum(self, name, description, entry_strings, default=None):
         """
@@ -294,6 +313,9 @@ class ParameterGenerator(object):
         self.nodename = nodename
         self.classname = classname
 
+        if self.parent:
+            eprint("You should not call generate on a group! Call it on the main parameter generator instead!")
+
         self._generatecfg()
         self._generatecpp()
 
@@ -309,35 +331,8 @@ class ParameterGenerator(object):
         with open(templatefile, 'r') as f:
             template = f.read()
 
-        param_entries = []
-        dynamic_params = [p for p in self.parameters if p["configurable"]]
-
-        for enum in self.enums:
-            param_entries.append(Template("$name = gen.enum([").substitute(name=enum['name']))
-            i = 0
-            for value in enum['values']:
-                param_entries.append(
-                    Template("    gen.const(name='$name', type='$type', value=$value, descr='$descr'),").substitute(
-                        name=value, type="int", value=i, descr=""))
-                i += 1
-            param_entries.append(Template("    ], '$description')").substitute(description=enum["description"]))
-
-        for param in dynamic_params:
-            content_line = Template("gen.add(name = '$name', paramtype = '$paramtype', level = $level, "
-                                    "description = '$description', edit_method=$edit_method").substitute(
-                name=param["name"],
-                paramtype=param['pytype'],
-                level=param['level'],
-                edit_method=param['edit_method'],
-                description=param['description'])
-            if param['default'] is not None:
-                content_line += Template(", default=$default").substitute(default=self._get_pyvalue(param, "default"))
-            if param['min'] is not None:
-                content_line += Template(", min=$min").substitute(min=param['min'])
-            if param['max'] is not None:
-                content_line += Template(", max=$max").substitute(max=param['max'])
-            content_line += ")"
-            param_entries.append(content_line)
+        param_entries = self._generate_param_entries()
+        print(param_entries)
 
         param_entries = "\n".join(param_entries)
         template = Template(template).substitute(pkgname=self.pkgname, nodename=self.nodename,
@@ -373,8 +368,10 @@ class ParameterGenerator(object):
         from_config = []
         test_limits = []
 
+        params = self._get_parameters()
+
         # Create dynamic parts of the header file for every parameter
-        for param in self.parameters:
+        for param in params:
             name = param['name']
 
             # Adjust key for parameter server
@@ -449,6 +446,65 @@ class ParameterGenerator(object):
             pass
         with open(header_file, 'w') as f:
             f.write(content)
+
+    def _get_parameters(self):
+        """
+        Returns parameter of this and all childs
+        :return: list of all parameters
+        """
+        params = self.parameters
+        for child in self.childs:
+            params.extend(child._get_parameters())
+        return params
+
+    def _generate_param_entries(self):
+        """
+        Generates the entries for the cfg-file
+        :return: list of param entries as string
+        """
+        param_entries = []
+        dynamic_params = [p for p in self.parameters if p["configurable"]]
+
+        if self.parent:
+            param_entries.append(Template("$group_variable = $parent.add_group('$group')").substitute(
+                group_variable=self.group_variable,
+                group=self.group,
+                parent=self.parent.group_variable))
+
+        for enum in self.enums:
+            param_entries.append(Template("$name = $group_variable.enum([").substitute(
+                group_variable=self.group_variable,
+                name=enum['name'],
+                parent=self.group))
+            i = 0
+            for value in enum['values']:
+                param_entries.append(
+                    Template("    $group_variable.const(name='$name', type='$type', value=$value, descr='$descr'),")
+                        .substitute(group_variable=self.group_variable, name=value, type="int", value=i, descr=""))
+                i += 1
+            param_entries.append(Template("    ], '$description')").substitute(description=enum["description"]))
+
+        for param in dynamic_params:
+            content_line = Template("$group_variable.add(name = '$name', paramtype = '$paramtype', level = $level, "
+                                    "description = '$description', edit_method=$edit_method").substitute(
+                group_variable=self.group_variable,
+                name=param["name"],
+                paramtype=param['pytype'],
+                level=param['level'],
+                edit_method=param['edit_method'],
+                description=param['description'])
+            if param['default'] is not None:
+                content_line += Template(", default=$default").substitute(default=self._get_pyvalue(param, "default"))
+            if param['min'] is not None:
+                content_line += Template(", min=$min").substitute(min=param['min'])
+            if param['max'] is not None:
+                content_line += Template(", max=$max").substitute(max=param['max'])
+            content_line += ")"
+            param_entries.append(content_line)
+
+        for child in self.childs:
+            param_entries.extend(child._generate_param_entries())
+        return param_entries
 
     @staticmethod
     def _make_bool(param):

--- a/src/rosparam_handler/parameter_generator_catkin.py
+++ b/src/rosparam_handler/parameter_generator_catkin.py
@@ -472,15 +472,14 @@ class ParameterGenerator(object):
                 parent=self.parent.group_variable))
 
         for enum in self.enums:
-            param_entries.append(Template("$name = $group_variable.enum([").substitute(
-                group_variable=self.group_variable,
+            param_entries.append(Template("$name = gen.enum([").substitute(
                 name=enum['name'],
                 parent=self.group))
             i = 0
             for value in enum['values']:
                 param_entries.append(
-                    Template("    $group_variable.const(name='$name', type='$type', value=$value, descr='$descr'),")
-                        .substitute(group_variable=self.group_variable, name=value, type="int", value=i, descr=""))
+                    Template("    gen.const(name='$name', type='$type', value=$value, descr='$descr'),")
+                        .substitute(name=value, type="int", value=i, descr=""))
                 i += 1
             param_entries.append(Template("    ], '$description')").substitute(description=enum["description"]))
 


### PR DESCRIPTION
This makes it possible to add group of dynamic parameters in the dynamic_reconfigure window. 

Being in a group does not change the name of the resulting parameter, it only affects how parameter are displayed in dynamic_reconfigure. It is also possible to create nested groups. 

This MR basically emulates the add_group function of dynamic_reconfigure.