### PR TITLE
Min max vector map

### DIFF
--- a/doc/HowToWriteYourFirstParamsFile.md
+++ b/doc/HowToWriteYourFirstParamsFile.md
@@ -38,7 +38,7 @@ gen.add("age", paramtype="int",description="Normal age of a human is inbetween 0
 gen.add("default_param", paramtype="std::string",description="Parameter with default value", default="Hello World")
 # Default vector/map
 gen.add("vector_bool", paramtype="std::vector<bool>", description="A vector of boolean with default value.", default=[False, True, True, False, True])
-gen.add("map_string_float", paramtype="std::map<std::string,float>", description="A map of <std::string,float> with default value.", default={"a":0.1, "b":1.2, "c":2.3, "d":3.4, "e":4.5})
+gen.add("map_string_float", paramtype="std::map<std::string,float>", description="A map of <std::string,float> with default value.", default={"a":0.1, "b":1.2, "c":2.3, "d":3.4, "e":4.5}, min=0, max=5)
 
 # Constant and configurable parameters
 gen.add("optimal_parameter", paramtype="double", description="Optimal parameter, can not be set via rosparam", default=10, constant=True)

--- a/src/rosparam_handler/parameter_generator_catkin.py
+++ b/src/rosparam_handler/parameter_generator_catkin.py
@@ -168,9 +168,21 @@ class ParameterGenerator(object):
         if in_type.startswith('std::map'):
             param['is_map'] = True
 
-        if (param['is_vector'] or param['is_map']):
+        if (param['is_vector']):
             if (param['max'] is not None or param['min'] is not None):
-                eprint(param['name'], "Max and min can not be specified for variable of type %s" % param['type'])
+                ptype = in_type[12:-1].strip()
+                if ptype == "std::string":
+                    eprint(param['name'], "Max and min can not be specified for variable of type %s" % param['type'])
+
+        if (param['is_map']):
+            if (param['max'] is not None or param['min'] is not None):
+                ptype = in_type[9:-1].split(',')
+                if len(ptype) != 2:
+                    eprint(param['name'], "Wrong syntax used for setting up std::map<... , ...>: You provided '%s' with "
+                           "parameter %s" % in_type)
+                ptype = ptype[1].strip()
+                if ptype == "std::string":
+                    eprint(param['name'], "Max and min can not be specified for variable of type %s" % param['type'])
 
         pattern = r'^[a-zA-Z][a-zA-Z0-9_]*$'
         if not re.match(pattern, param['name']):

--- a/templates/Parameters.h.template
+++ b/templates/Parameters.h.template
@@ -56,6 +56,16 @@ std::ostream &operator<<(std::ostream &stream, const std::map<T1, T2>& map)
   return stream;
 }
 
+template <typename T>
+using is_vector = std::is_same<T, std::vector<typename T::value_type,
+                                              typename T::allocator_type>>;
+
+template <typename T>
+using is_map = std::is_same<T, std::map<typename T::key_type,
+                                        typename T::mapped_type,
+                                        typename T::key_compare,
+                                        typename T::allocator_type>>;
+
 #endif /* UTIL_FUNCTIONS_${pkgname} */
 
 struct ${ClassName}Parameters {
@@ -125,19 +135,47 @@ $non_default_params    );
   }
 
   template<typename T>
-  void testMin(const std::string key, T& val, T min = std::numeric_limits<T>::min()){
+  typename std::enable_if<std::is_arithmetic<T>::value, void>::type
+  testMin(const std::string key, T& val, T min = std::numeric_limits<T>::min()){
     if (val < min){
-      ROS_WARN_STREAM("Value of " << val << " for " << key << " is smaller than minimal allowed value. Correcting value to min=" << min);
+      ROS_WARN_STREAM("Value of " << val << " for "
+                      << key << " is smaller than minimal allowed value. Correcting value to min=" << min);
       val = min;
     }
   }
 
   template<typename T>
-  void testMax(const std::string key, T& val, T max = std::numeric_limits<T>::max()){
+  typename std::enable_if<is_vector<T>::value && std::is_arithmetic<typename T::value_type>::value, void>::type
+  testMin(const std::string key, T& val, typename T::value_type min = std::numeric_limits<typename T::value_type>::min()){
+    for (auto& v : val) testMin(key, v, min);
+  }
+
+  template<typename T>
+  typename std::enable_if<is_map<T>::value && std::is_arithmetic<typename T::mapped_type>::value, void>::type
+  testMin(const std::string key, T& val, typename T::mapped_type min = std::numeric_limits<typename T::mapped_type>::min()){
+    for (auto& v : val) testMin(key, v.second, min);
+  }
+
+  template<typename T>
+  typename std::enable_if<std::is_arithmetic<T>::value, void>::type
+  testMax(const std::string key, T& val, T max = std::numeric_limits<T>::max()){
     if (val > max){
-      ROS_WARN_STREAM("Value of " << val << " for " << key << " is greater than maximal allowed. Correcting value to max=" << max);
+      ROS_WARN_STREAM("Value of " << val << " for "
+                      << key << " is greater than maximal allowed. Correcting value to max=" << max);
       val = max;
     }
+  }
+
+  template<typename T>
+  typename std::enable_if<is_vector<T>::value && std::is_arithmetic<typename T::value_type>::value, void>::type
+  testMax(const std::string key, T& val, typename T::value_type min = std::numeric_limits<typename T::value_type>::max()){
+    for (auto& v : val) testMax(key, v, min);
+  }
+
+  template<typename T>
+  typename std::enable_if<is_map<T>::value && std::is_arithmetic<typename T::mapped_type>::value, void>::type
+  testMax(const std::string key, T& val, typename T::mapped_type min = std::numeric_limits<typename T::mapped_type>::max()){
+    for (auto& v : val) testMax(key, v.second, min);
   }
 
   $parameters


### PR DESCRIPTION
I finally encountered a use-case for the min/max feature in `std::vector` :D 

This PR enable min/max for `std::vector` & `std::map` if their `value_type` - `mapped_type` are not `std::string`.