### PR TITLE
Fix initialisation order in parameter class template

### DIFF
--- a/templates/Parameters.h.template
+++ b/templates/Parameters.h.template
@@ -73,9 +73,9 @@ struct ${ClassName}Parameters {
   using Config = ${ClassName}Config;
 
   ${ClassName}Parameters(const ros::NodeHandle& private_node_handle)
-  : privateNamespace{private_node_handle.getNamespace() + "/"},
-    nodeName{getNodeName(private_node_handle)},
-    globalNamespace{"/"} {}
+  : globalNamespace{"/"},
+    privateNamespace{private_node_handle.getNamespace() + "/"},
+    nodeName{getNodeName(private_node_handle)} {}
 
   void fromParamServer(){
 $fromParamServer

--- a/templates/Parameters.h.template
+++ b/templates/Parameters.h.template
@@ -30,7 +30,7 @@ struct ${ClassName}Parameters {
   ${ClassName}Parameters(const ros::NodeHandle& private_node_handle)
   : globalNamespace{"/"},
     privateNamespace{private_node_handle.getNamespace() + "/"},
-    nodeName{getNodeName(private_node_handle)} {}
+    nodeName{rosparam_handler::getNodeName(private_node_handle)} {}
 
   void fromParamServer(){
 $fromParamServer


### PR DESCRIPTION
The current implementation produces compiler warnings by the order things are initialized.