### PR TITLE
Set default values on parameter server if no value is set

### DIFF
--- a/doc/HowToUseYourParameterStruct.md
+++ b/doc/HowToUseYourParameterStruct.md
@@ -25,7 +25,7 @@ rosparam_tutorials::TutorialParameters params_;
 ## Initializing the struct.
 When initializing your node, the params struct must be initialized with a private NodeHandle.
 
-The call to `fromParamServer()` will take care of getting all parameter values from the parameter server, checking their type, and checking that a default value is set, if you haven't provided one on your own. When min and max values are specified, these bounds will be checked as well.
+The call to `fromParamServer()` will take care of getting all parameter values from the parameter server, checking their type, and checking that a default value is set, if you haven't provided one on your own. If you have specified a default value, but the parameter is not yet present on the parameter server, it will be set. When min and max values are specified, these bounds will be checked as well.
 
 ```cpp
 MyNodeClass::MyNodeClass()

--- a/templates/Parameters.h.template
+++ b/templates/Parameters.h.template
@@ -122,6 +122,8 @@ $non_default_params    );
   void getParam(const std::string key, T& val, const T& defaultValue) {
     if (!ros::param::has(key)) {
         val = defaultValue;
+        ros::param::set(key, defaultValue);
+        ROS_INFO_STREAM("Parameter "<<key<<" is not yet set. Setting default value.");
     } else if (!ros::param::get(key, val)) {
         ROS_WARN_STREAM("Parameter "<<key<<" is set, but has a different type. Using default value instead.");
         val = defaultValue;

--- a/test/src/test_defaults.cpp
+++ b/test/src/test_defaults.cpp
@@ -19,8 +19,66 @@ TEST(RosparamHandler, Defaults) {
     ASSERT_EQ(std::vector<bool>({false, true}), testParams.vector_bool_param_w_default);
     ASSERT_EQ(std::vector<std::string>({"Hello", "World"}), testParams.vector_string_param_w_default);
 
-	std::map<std::string,std::string> tmp{{"Hello","World"}};
+    std::map<std::string,std::string> tmp{{"Hello","World"}};
     ASSERT_EQ(tmp, testParams.map_param_w_default);
 
     ASSERT_EQ(1, testParams.enum_param_w_default);
+}
+
+TEST(RosparamHandler, DefaultsOnParamServer) {
+    ros::NodeHandle nh("~");
+    ParamType testParams(nh);
+    ASSERT_NO_THROW(testParams.fromParamServer());
+
+    // values should now be set on param server
+    {
+        int int_param;
+        ASSERT_TRUE(nh.getParam("int_param_w_default", int_param));
+        ASSERT_EQ(int_param, testParams.int_param_w_default);
+    }
+    {
+        double double_param;
+        ASSERT_TRUE(nh.getParam("double_param_w_default", double_param));
+        EXPECT_EQ(double_param, testParams.double_param_w_default);
+    }
+    {
+        bool bool_param;
+        ASSERT_TRUE(nh.getParam("bool_param_w_default", bool_param));
+        EXPECT_EQ(bool_param, testParams.bool_param_w_default);
+    }
+    {
+        bool bool_param;
+        ASSERT_TRUE(nh.getParam("bool_param_w_default", bool_param));
+        EXPECT_EQ(bool_param, testParams.bool_param_w_default);
+    }
+    {
+        std::vector<int> vector_int_param;
+        ASSERT_TRUE(nh.getParam("vector_int_param_w_default", vector_int_param));
+        EXPECT_EQ(vector_int_param, testParams.vector_int_param_w_default);
+    }
+    {
+        std::vector<double> vector_double_param;
+        ASSERT_TRUE(nh.getParam("vector_double_param_w_default", vector_double_param));
+        EXPECT_EQ(vector_double_param, testParams.vector_double_param_w_default);
+    }
+    {
+        std::vector<bool> vector_bool_param;
+        ASSERT_TRUE(nh.getParam("vector_bool_param_w_default", vector_bool_param));
+        EXPECT_EQ(vector_bool_param, testParams.vector_bool_param_w_default);
+    }
+    {
+        std::vector<std::string> vector_string_param;
+        ASSERT_TRUE(nh.getParam("vector_string_param_w_default", vector_string_param));
+        EXPECT_EQ(vector_string_param, testParams.vector_string_param_w_default);
+    }
+    {
+        std::map<std::string, std::string> map_param_w_default;
+        ASSERT_TRUE(nh.getParam("map_param_w_default", map_param_w_default));
+        EXPECT_EQ(map_param_w_default, testParams.map_param_w_default);
+    }
+    {
+        int enum_param;
+        ASSERT_TRUE(nh.getParam("enum_param_w_default", enum_param));
+        EXPECT_EQ(enum_param, testParams.enum_param_w_default);
+    }
 }

--- a/test/src/test_defaults.cpp
+++ b/test/src/test_defaults.cpp
@@ -47,11 +47,6 @@ TEST(RosparamHandler, DefaultsOnParamServer) {
         EXPECT_EQ(bool_param, testParams.bool_param_w_default);
     }
     {
-        bool bool_param;
-        ASSERT_TRUE(nh.getParam("bool_param_w_default", bool_param));
-        EXPECT_EQ(bool_param, testParams.bool_param_w_default);
-    }
-    {
         std::vector<int> vector_int_param;
         ASSERT_TRUE(nh.getParam("vector_int_param_w_default", vector_int_param));
         EXPECT_EQ(vector_int_param, testParams.vector_int_param_w_default);

--- a/test/src/test_defaultsAtLaunch.cpp
+++ b/test/src/test_defaultsAtLaunch.cpp
@@ -19,7 +19,7 @@ TEST(RosparamHandler, DefaultsAtLaunch) {
     ASSERT_EQ(std::vector<bool>({false, true}), testParams.vector_bool_param_wo_default);
     ASSERT_EQ(std::vector<std::string>({"Hello", "World"}), testParams.vector_string_param_wo_default);
 
-	std::map<std::string,std::string> tmp{{"Hello","World"}};
+    std::map<std::string,std::string> tmp{{"Hello","World"}};
     ASSERT_EQ(tmp, testParams.map_param_wo_default);
 
     ASSERT_EQ(1, testParams.enum_param_wo_default);


### PR DESCRIPTION
We found it useful to set the default parameters on the rosparam server if they were not present so that the full configuration of a node is visible.