### PR TITLE
Fix CI Breaking on External Projects

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -31,7 +31,7 @@ install(
 )
 
 install(
-        DIRECTORY include/rosparam_handler
+        DIRECTORY include/rosparam_handler/
         DESTINATION ${CATKIN_PACKAGE_INCLUDE_DESTINATION}
 )
 


### PR DESCRIPTION
Our CI breaks when we use the released version on apt or from source.

The error is:
```
dynamic_reconfigure_Parameters.h:13:42: fatal error: rosparam_handler/utilities.hpp: No such file or directory
```

This change results in our builds passing [here](https://travis-ci.org/shaun-edwards/moveit_simple/jobs/346481212).