### PR TITLE
Fix wrong error message

### DIFF
--- a/include/rosparam_handler/utilities.hpp
+++ b/include/rosparam_handler/utilities.hpp
@@ -151,7 +151,7 @@ inline bool getParam(const std::string key, T& val) {
 /// \param defaultValue Parameter default value
 template <typename T>
 inline bool getParam(const std::string key, T& val, const T& defaultValue) {
-    if (!ros::param::has(key) && !ros::param::get(key, val)) {
+    if (!ros::param::has(key) || !ros::param::get(key, val)) {
         val = defaultValue;
         ros::param::set(key, defaultValue);
         ROS_INFO_STREAM("Setting default value for parameter '" << key << "'.");

--- a/include/rosparam_handler/utilities.hpp
+++ b/include/rosparam_handler/utilities.hpp
@@ -151,10 +151,10 @@ inline bool getParam(const std::string key, T& val) {
 /// \param defaultValue Parameter default value
 template <typename T>
 inline bool getParam(const std::string key, T& val, const T& defaultValue) {
-    if (!getParam(key, val)) {
+    if (!ros::param::has(key) && !ros::param::get(key, val)) {
         val = defaultValue;
         ros::param::set(key, defaultValue);
-        ROS_INFO_STREAM("Setting default value.");
+        ROS_INFO_STREAM("Setting default value for parameter '" << key << "'.");
         return true;
     } else {
         // Param was already retrieved with last if statement.


### PR DESCRIPTION
Do not print error message while retrieving a param with default value.

Fix #47 .